### PR TITLE
Dedupe characters

### DIFF
--- a/dracor-oxygen-framework.xpr
+++ b/dracor-oxygen-framework.xpr
@@ -28,7 +28,7 @@
                                 </field>
                                 <field name="scenarioIds">
                                     <list>
-                                        <String>3/dracor/dracor.framework/dracor/dracor (staging)</String>
+                                        <String>3/dracor/dracor.framework/dracor/TEI all</String>
                                     </list>
                                 </field>
                                 <field name="scenarioTypes">

--- a/dracor/css/dedupe_characters.css
+++ b/dracor/css/dedupe_characters.css
@@ -1,0 +1,155 @@
+/*  @import "css-tei-framework/tei_oxygen.css"; */
+
+/* Character Deduplication */
+
+TEI {
+    display:block;
+}
+
+TEI::before {
+    content:"Character Deduplication";
+    font-size:large;
+}
+
+teiHeader {
+    display:block;
+}
+
+titleStmt {
+    display:none;
+}
+
+fileDesc {
+    display:none;
+}
+
+publicationStmt {
+    display:none;
+}
+
+sourceDesc {
+    display: none;
+}
+
+profileDesc {
+    display:block;
+    padding:2em;
+    
+}
+
+particDesc:before {
+    display:block;
+    content:"particDesc";
+    font-weight:bold;
+    font-size:large;
+}
+
+particDesc:after {
+    content: "Here comes a nice button to run a XSLT"
+}
+
+person, personGrp {
+    margin:1em;
+    display:block;
+}
+
+personGrp:after {
+    display:block;
+    content: "@xml:id: " oxy_textfield( edit, "@xml:id", values, " ", color, "black", columns, 30) "\A @sex:" oxy_combobox( edit, "@sex", editable, false, values, "UNKNOWN, FEMALE, MALE", labels, "UNKNOWN, FEMALE, MALE");
+    color:gray;
+}
+
+person:after {
+    display:block;
+    content: "@xml:id: " oxy_textfield( edit, "@xml:id", values, " ", color, "black", columns, 30) "\A @sameAs: "oxy_combobox( edit, "@sameAs", editable, false, values, oxy_xpath("concat('none,','#',string-join(./ancestor::TEI//particDesc//person/@xml:id/string(),',#'))"), labels, oxy_xpath("concat('none,','#',string-join(./ancestor::TEI//particDesc//person/@xml:id/string(),',#'))"));
+    color:gray;
+}
+
+person[sameAs] {
+    background-color:#ffcccc;
+}
+
+persName {
+    display:block;
+    color:black;
+}
+
+revisionDesc {
+    display:none;
+}
+
+div[type=Dramatis_Personae] {
+    display:block;
+    padding:2em;
+}
+
+div[type=Dramatis_Personae]:before {
+    display:block;
+    content:"Dramatis personae";
+    font-weight:bold;
+    font-size:large;
+}
+
+set {
+    display:none;
+}
+
+castItem {
+    display:block;
+}
+
+body {
+    display:block;
+    margin-left:1em;
+}
+
+
+sp {
+    display:block;
+    margin-top:1em;
+}
+
+speaker {
+    display:block;
+    font-weight:bold;
+    color:purple;
+}
+
+sp > p {
+    display:block;
+    font-size:small;
+}
+
+sp > stage {
+    font-size:small;
+
+}
+
+sp:before {
+    display:block;
+    content: "@who: "oxy_combobox( edit, "@who", editable, false, values, oxy_xpath("concat('none,','#',string-join(./ancestor::TEI//particDesc//person/@xml:id/string(),',#'))"), labels, oxy_xpath("concat('none,','#',string-join(./ancestor::TEI//particDesc//person/@xml:id/string(),',#'))"))
+}
+
+body {
+    margin-left:2em;
+}
+
+body > div > head {
+    display:block;
+    font-weight:bold;
+    font-size:large;
+}
+
+body > div {
+    margin-top:2em;
+}
+
+body > div > div {
+    margin-top:1em;
+}
+
+body > div > div > head {
+    display:block;
+    font-weight:bold;
+    font-size:large;
+}

--- a/dracor/css/dedupe_characters.css
+++ b/dracor/css/dedupe_characters.css
@@ -45,7 +45,7 @@ particDesc:before {
 }
 
 particDesc:after {
-    content: "Here comes a nice button to run a XSLT"
+    content:"Run " oxy_button(actionID, 'dedupe_characters', showText, false);
 }
 
 person, personGrp {

--- a/dracor/css/dedupe_characters.css
+++ b/dracor/css/dedupe_characters.css
@@ -7,7 +7,7 @@ TEI {
 }
 
 TEI::before {
-    content:"Character Deduplication";
+    content:"Character Deduplication \A Set the attribute @sameAs to a character ID if the given character is a duplicate. Running the deduplication process will remove the character with the @sameAs attribute and change the value of the @who attribute accordingly.";
     font-size:large;
 }
 
@@ -39,7 +39,7 @@ profileDesc {
 
 particDesc:before {
     display:block;
-    content:"particDesc";
+    content:"Characters (particDesc)";
     font-weight:bold;
     font-size:large;
 }
@@ -72,6 +72,7 @@ person[sameAs] {
 persName {
     display:block;
     color:black;
+    font-weight:bold;
 }
 
 revisionDesc {

--- a/dracor/dracor.framework
+++ b/dracor/dracor.framework
@@ -89,6 +89,17 @@
 											<Boolean>true</Boolean>
 										</field>
 									</cssFile>
+									<cssFile>
+										<field name="href">
+											<String>${framework}/css/dedupe_characters.css</String>
+										</field>
+										<field name="title">
+											<String>Character Deduplication</String>
+										</field>
+										<field name="alternate">
+											<Boolean>true</Boolean>
+										</field>
+									</cssFile>
 								</cssFile-array>
 							</field>
 							<field name="mergeCSSsFromDocument">

--- a/dracor/dracor.framework
+++ b/dracor/dracor.framework
@@ -12,7 +12,7 @@
 						<null/>
 					</field>
 					<field name="name">
-						<String>dracor</String>
+						<String>DraCor</String>
 					</field>
 					<field name="schemaDescriptor">
 						<docTypeSchema>
@@ -386,6 +386,52 @@
 											<Boolean>false</Boolean>
 										</field>
 									</action>
+									<action>
+										<field name="id">
+											<String>dedupe_characters</String>
+										</field>
+										<field name="name">
+											<String>Character Deduplication</String>
+										</field>
+										<field name="description">
+											<String>Deduplication of Characters</String>
+										</field>
+										<field name="largeIconPath">
+											<String></String>
+										</field>
+										<field name="smallIconPath">
+											<String></String>
+										</field>
+										<field name="accessKey">
+											<String></String>
+										</field>
+										<field name="accelerator">
+											<null/>
+										</field>
+										<field name="actionModes">
+											<actionMode-array>
+												<actionMode>
+													<field name="xpathCondition">
+														<String></String>
+													</field>
+													<field name="argValues">
+														<serializableOrderedMap>
+															<entry>
+																<String>scenarioName</String>
+																<String>Character Deduplication</String>
+															</entry>
+														</serializableOrderedMap>
+													</field>
+													<field name="operationID">
+														<String>ro.sync.ecss.extensions.commons.operations.ExecuteCustomizableTransformationScenarioOperation</String>
+													</field>
+												</actionMode>
+											</actionMode-array>
+										</field>
+										<field name="enabledInReadOnlyContext">
+											<Boolean>false</Boolean>
+										</field>
+									</action>
 								</action-array>
 							</field>
 							<field name="menubarDescriptor">
@@ -737,6 +783,89 @@
 								</field>
 								<field name="inputXSLURL">
 									<String>${framework}/xsl/generate_particDesc_from_who.xsl</String>
+								</field>
+								<field name="inputXMLURL">
+									<String>${currentFileURL}</String>
+								</field>
+								<field name="defaultScenario">
+									<Boolean>false</Boolean>
+								</field>
+								<field name="isFOPPerforming">
+									<Boolean>false</Boolean>
+								</field>
+								<field name="type">
+									<String>XSL</String>
+								</field>
+								<field name="saveAs">
+									<Boolean>true</Boolean>
+								</field>
+								<field name="openInBrowser">
+									<Boolean>false</Boolean>
+								</field>
+								<field name="outputResource">
+									<String>${cf}</String>
+								</field>
+								<field name="openOtherLocationInBrowser">
+									<Boolean>false</Boolean>
+								</field>
+								<field name="locationToOpenInBrowserURL">
+									<null/>
+								</field>
+								<field name="openInEditor">
+									<Boolean>false</Boolean>
+								</field>
+								<field name="showInHTMLPane">
+									<Boolean>false</Boolean>
+								</field>
+								<field name="showInXMLPane">
+									<Boolean>false</Boolean>
+								</field>
+								<field name="showInSVGPane">
+									<Boolean>false</Boolean>
+								</field>
+								<field name="showInResultSetPane">
+									<Boolean>false</Boolean>
+								</field>
+								<field name="useXSLTInput">
+									<Boolean>true</Boolean>
+								</field>
+								<field name="xsltParams">
+									<list/>
+								</field>
+								<field name="cascadingStylesheets">
+									<String-array/>
+								</field>
+								<field name="xslTransformer">
+									<String>Saxon-PE</String>
+								</field>
+								<field name="extensionURLs">
+									<String-array/>
+								</field>
+							</scenario>
+							<scenario>
+								<field name="advancedOptionsMap">
+									<null/>
+								</field>
+								<field name="name">
+									<String>Character Deduplication</String>
+								</field>
+								<field name="baseURL">
+									<String></String>
+								</field>
+								<field name="footerURL">
+									<String></String>
+								</field>
+								<field name="fOPMethod">
+									<String>pdf</String>
+								</field>
+								<field name="fOProcessorName">
+									<String>Apache FOP</String>
+								</field>
+								<field name="headerURL">
+									<String></String>
+								</field>
+								<field name="inputXSLURL">
+									<String>${framework}/xsl/dedupe_characters.xsl</String>
 								</field>
 								<field name="inputXMLURL">
 									<String>${currentFileURL}</String>

--- a/dracor/xsl/dedupe_characters.xsl
+++ b/dracor/xsl/dedupe_characters.xsl
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:tei="http://www.tei-c.org/ns/1.0">
+    
+    <xsl:template match="@*|*|processing-instruction()|comment()|node()">
+        <xsl:copy>
+            <xsl:apply-templates select="@*|*|processing-instruction()|comment()|node()"/>
+        </xsl:copy>
+    </xsl:template>
+    
+    <xsl:template match="tei:person[@sameAs]">
+        <xsl:comment>Something needs to be done here</xsl:comment>
+    </xsl:template>
+    
+    <xsl:template match="tei:sp">
+        <xsl:variable name="character_id" select="substring-after(@who,'#')"/>
+        <!-- <xsl:value-of select="$character_id"/> -->
+        <!-- Get the person element -->
+        <xsl:choose>
+            
+            <!-- Change the who attribute if there is an person element with a sameAs attribute that indicates this is a doublette -->
+            <xsl:when test="./ancestor::tei:TEI//tei:person[@xml:id eq $character_id][@sameAs]">
+                <xsl:comment>This was changed:</xsl:comment>
+                <xsl:copy>
+                    <xsl:attribute name="who" select="./ancestor::tei:TEI//tei:person[@xml:id eq $character_id]/@sameAs"/>
+                    <!-- keep arbitraty attributes -->
+                    <xsl:copy-of select="@*[./name() !='who']"/>
+                    <xsl:copy-of select="*"/>
+                </xsl:copy>
+               
+            </xsl:when>
+            
+            <xsl:otherwise>
+                <xsl:copy-of select="."/>
+            </xsl:otherwise>
+        </xsl:choose>
+        
+        
+    </xsl:template>
+    
+    
+</xsl:stylesheet>

--- a/dracor/xsl/dedupe_characters.xsl
+++ b/dracor/xsl/dedupe_characters.xsl
@@ -8,7 +8,7 @@
     </xsl:template>
     
     <xsl:template match="tei:person[@sameAs]">
-        <xsl:comment>Something needs to be done here</xsl:comment>
+        <!-- <xsl:comment>Something needs to be done here</xsl:comment> -->
     </xsl:template>
     
     <xsl:template match="tei:sp">
@@ -19,7 +19,7 @@
             
             <!-- Change the who attribute if there is an person element with a sameAs attribute that indicates this is a doublette -->
             <xsl:when test="./ancestor::tei:TEI//tei:person[@xml:id eq $character_id][@sameAs]">
-                <xsl:comment>This was changed:</xsl:comment>
+                <!-- <xsl:comment>This was changed:</xsl:comment> -->
                 <xsl:copy>
                     <xsl:attribute name="who" select="./ancestor::tei:TEI//tei:person[@xml:id eq $character_id]/@sameAs"/>
                     <!-- keep arbitraty attributes -->

--- a/examples/ham_as_egg.xml
+++ b/examples/ham_as_egg.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Basic File to Test the Features of DraCor Plays -->
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="tst000000" xml:lang="eng">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title type="main">Ham</title>
+                <title type="sub">A Tragedy</title>
+                <author>William S</author>
+            </titleStmt>
+            <publicationStmt>
+                <publisher xml:id="dracor">DraCor</publisher>
+                <idno type="URL">https://dracor.org</idno>
+                <availability>
+                    <licence>
+                        <ab>CC0 1.0</ab>
+                        <ref target="https://creativecommons.org/publicdomain/zero/1.0/"
+                            >Licence</ref>
+                    </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <bibl type="digitalSource">
+                    <name>dracor-schema GitHub Repository</name>
+                    <bibl type="originalSource">
+                        <title>Slides of the Hebrew and Yiddish DraCor Working group meeting on 2022-11-14 by Daniil Skorinkin</title>
+                    </bibl>
+                </bibl>
+            </sourceDesc>
+        </fileDesc>
+        <profileDesc>
+            <particDesc>
+                <listPerson>
+                    <person xml:id="ham">
+                        <persName>Ham</persName>
+                    </person>
+                    <person xml:id="egg">
+                        <persName>Egg</persName>
+                    </person>
+                    <person xml:id="sausage">
+                        <persName>Sausage</persName>
+                    </person>
+                    <person xml:id="bacon">
+                        <persName>Bacon</persName>
+                    </person>
+                </listPerson>
+            </particDesc>
+        </profileDesc>
+        <revisionDesc>
+            <change when="2022-11-07">Describe Change!</change>
+        </revisionDesc>
+    </teiHeader>
+    <standOff>
+        <listEvent>
+            <event type="print" when="2023">
+                <desc/>
+            </event>
+            <event type="written" when="2022">
+                <desc/>
+            </event>
+        </listEvent>
+    </standOff>
+    <text>
+        <front>
+            <div type="front">
+                <head>Ham, a tragedy By William S</head>
+            </div>
+            <div type="Dramatis_Personae">
+                <castList>
+                    <head>Dramatis Personae</head>
+                    <castItem>Ham</castItem>
+                    <castItem>Egg</castItem>
+                    <castGroup>
+                        <castItem>Sausage</castItem>
+                        <castItem>Bacon</castItem>
+                        <roleDesc>Vikings</roleDesc>
+                    </castGroup>
+                </castList>
+            </div>
+        </front>
+        <body>
+            <div type="act">
+                <head>Act 1.</head>
+                <div type="scene">
+                    <head>Scene 1.</head>
+                    <stage>Ham and Egg.</stage>
+                    <sp who="#ham">
+                        <speaker>Ham.</speaker>
+                        <p>Lovely Spam!</p>
+                    </sp>
+                    <sp who="#egg">
+                        <speaker>Egg.</speaker>
+                        <p>Wonderful Spam!</p>
+                    </sp>
+                </div>
+                <div type="scene">
+                    <head>Scene 2.</head>
+                    <stage>Enter Vikings.</stage>
+                    <sp who="#ham">
+                        <speaker>Ham.</speaker>
+                        <p>Egg! Sausage, and Bacon!</p>
+                    </sp>
+                    <sp who="#sausage #bacon">
+                        <speaker>Vikings</speaker>
+                        <stage>(singing).</stage>
+                        <l>Spam, Spam, Spam,</l>
+                        <l>Spam, Spam, Spam,</l>
+                        <l>Spam and Spam!</l>
+                    </sp>
+                    <stage>The End.</stage>
+                </div>
+            </div>
+            
+        </body>
+    </text>
+</TEI>

--- a/examples/ham_as_egg.xml
+++ b/examples/ham_as_egg.xml
@@ -1,6 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- Basic File to Test the Features of DraCor Plays -->
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="tst000000" xml:lang="eng">
+<?xml version="1.0" encoding="UTF-8"?><!-- Basic File to Test the Features of DraCor Plays --><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="tst000000" xml:lang="eng">
     <teiHeader>
         <fileDesc>
             <titleStmt>
@@ -14,8 +12,7 @@
                 <availability>
                     <licence>
                         <ab>CC0 1.0</ab>
-                        <ref target="https://creativecommons.org/publicdomain/zero/1.0/"
-                            >Licence</ref>
+                        <ref target="https://creativecommons.org/publicdomain/zero/1.0/">Licence</ref>
                     </licence>
                 </availability>
             </publicationStmt>
@@ -31,9 +28,7 @@
         <profileDesc>
             <particDesc>
                 <listPerson>
-                    <person xml:id="ham">
-                        <persName>Ham</persName>
-                    </person>
+                    
                     <person xml:id="egg">
                         <persName>Egg</persName>
                     </person>
@@ -84,10 +79,7 @@
                 <div type="scene">
                     <head>Scene 1.</head>
                     <stage>Ham and Egg.</stage>
-                    <sp who="#ham">
-                        <speaker>Ham.</speaker>
-                        <p>Lovely Spam!</p>
-                    </sp>
+                    <sp who="#egg"><speaker>Ham.</speaker><p>Lovely Spam!</p></sp>
                     <sp who="#egg">
                         <speaker>Egg.</speaker>
                         <p>Wonderful Spam!</p>
@@ -96,10 +88,7 @@
                 <div type="scene">
                     <head>Scene 2.</head>
                     <stage>Enter Vikings.</stage>
-                    <sp who="#ham">
-                        <speaker>Ham.</speaker>
-                        <p>Egg! Sausage, and Bacon!</p>
-                    </sp>
+                    <sp who="#egg"><speaker>Ham.</speaker><p>Egg! Sausage, and Bacon!</p></sp>
                     <sp who="#sausage #bacon">
                         <speaker>Vikings</speaker>
                         <stage>(singing).</stage>


### PR DESCRIPTION
Adding a Style/View and XSLT to do deduplication of characters based on the `@sameAs` Attribute on `<person>`: Duplicate characters are removed and the `@who` values of their `<sp>` are changed to the value of the character they are merged into. It does not work for `<personGrp>` and it does not work in case a `<sp>` is assigned to multiple speakers. It still need some testing which will be done in the context of the NeoLatDraCor Hackathon in Prague