### PR TITLE
Update templates to current DraCor schema

### DIFF
--- a/dracor/templates/NeoLatDraCor.xml
+++ b/dracor/templates/NeoLatDraCor.xml
@@ -1,106 +1,103 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://dracor.org/schema.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="neolatXXXXXX" xml:lang="la">
-   <teiHeader>
-      <fileDesc>
-         <titleStmt>
-            <title><!-- title --></title>
-            <author>
-               <persName xml:lang="la"><!-- author's name --></persName>
-               <idno type="wikidata"><!-- Wikidata ID of the author --></idno>
-            </author>
-            <respStmt>
-               <resp>Transcribed by</resp>
-               <persName><!-- Transcriber's name --></persName>
-            </respStmt>
-            <respStmt>
-               <resp>Converted to TEI under the supervision of</resp>
-               <persName><!-- Person Name --></persName>
-            </respStmt>
-            <respStmt>
-               <resp>Converted to TEI by</resp>
-               <persName><!-- Person Name --></persName>
-            </respStmt>
-            <funder>
-               <orgName><!-- Funder Name --></orgName>
-            </funder>
-         </titleStmt>
-         <publicationStmt>
-            <authority><!-- Authority Name --></authority>
-            <publisher xml:id="dracor">DraCor</publisher>
-            <idno type="URL">https://dracor.org</idno>
-            <availability>
-               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">CC0 1.0</licence>
-            </availability>
-         </publicationStmt>
-         <sourceDesc>
-            <bibl type="digitalSource">
-               <ref target="URL of digital source"><!-- Name of the Digital Source --></ref>
-               <availability>
-                  <licence target="URL of licence"><!-- Name of the Licence --></licence>
-               </availability>
-            </bibl>
-
-            <bibl type="originalSource">
-               <author><!-- Author Name --></author>:
-               <title><!-- Title --></title>.
-               <pubPlace><!-- Publication Place --></pubPlace>:
-               <publisher><!-- Publisher --></publisher>,
-               <date><!-- Year --></date>.
-            </bibl>
-
-            <bibl type="wikidata">
-               <idno><!-- Wikidata QID --></idno>
-            </bibl>
-
-            <listEvent>
-               <event type="print" when=""><!-- add year -->
-                  <desc/>
-               </event>
-            </listEvent>
-         </sourceDesc>
-      </fileDesc>
-      <profileDesc>
-         <particDesc>
-            <listPerson>
-               <person xml:id="character_id">
-                  <persName><!-- Character Name --></persName>
-               </person>
-               <!-- additional characters -->
-            </listPerson>
-         </particDesc>
-         <textClass>
-            <keywords>
-               <term type="genreTitle">Check!</term>
-            </keywords>
-            <classCode scheme="http://www.wikidata.org/entity/"><!-- Wikidata Code of the Genre --></classCode>
-         </textClass>
-         <creation>
-            <region>
-               <ref target="http://www.wikidata.org/entity/..."><!-- Name of the Region --></ref>
-            </region>
-         </creation>
-      </profileDesc>
-   </teiHeader>
-   <text>
-      <front>
-         <titlePage>
-            <docTitle>
-               <titlePart><!-- add title --></titlePart>
-            </docTitle>
-         </titlePage>
-      </front>
-      <body>
-         <div type="act" n="1">
-            <div type="scene" n="1">
-               <head><!-- heading of first act --></head>
-               <stage><!-- stage direction --></stage>
-               <sp who="#character_id">
-                  <speaker><!-- Speaker Label --></speaker>
-                  <l><!-- verse line --></l>
-               </sp>
-            </div>
-         </div>
-      </body>
-   </text>
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title><!-- title --></title>
+        <author>
+          <persName xml:lang="la"><!-- author's name --></persName>
+          <idno type="wikidata"><!-- Wikidata ID of the author --></idno>
+        </author>
+        <respStmt>
+          <resp>Transcribed by</resp>
+          <persName><!-- Transcriber's name --></persName>
+        </respStmt>
+        <respStmt>
+          <resp>Converted to TEI under the supervision of</resp>
+          <persName><!-- Person Name --></persName>
+        </respStmt>
+        <respStmt>
+          <resp>Converted to TEI by</resp>
+          <persName><!-- Person Name --></persName>
+        </respStmt>
+        <funder>
+          <orgName><!-- Funder Name --></orgName>
+        </funder>
+      </titleStmt>
+      <publicationStmt>
+        <authority><!-- Authority Name --></authority>
+        <publisher xml:id="dracor">DraCor</publisher>
+        <idno type="URL">https://dracor.org</idno>
+        <availability>
+          <licence target="https://creativecommons.org/publicdomain/zero/1.0/">CC0 1.0</licence>
+        </availability>
+      </publicationStmt>
+      <sourceDesc>
+        <bibl type="digitalSource">
+          <ref target="URL of digital source"><!-- Name of the Digital Source --></ref>
+          <availability>
+            <licence target="URL of licence"><!-- Name of the Licence --></licence>
+          </availability>
+        </bibl>
+        <bibl type="originalSource">
+          <author><!-- Author Name --></author>:
+          <title><!-- Title --></title>.
+          <pubPlace><!-- Publication Place --></pubPlace>:
+          <publisher><!-- Publisher --></publisher>,
+          <date><!-- Year --></date>.
+        </bibl>
+        <bibl type="wikidata">
+          <idno><!-- Wikidata QID --></idno>
+        </bibl>
+        <listEvent>
+          <event type="print" when=""><!-- add year -->
+            <desc/>
+          </event>
+        </listEvent>
+      </sourceDesc>
+    </fileDesc>
+    <profileDesc>
+      <particDesc>
+        <listPerson>
+          <person xml:id="character_id">
+            <persName><!-- Character Name --></persName>
+          </person>
+          <!-- additional characters -->
+        </listPerson>
+      </particDesc>
+      <textClass>
+        <keywords>
+          <term type="genreTitle">Check!</term>
+        </keywords>
+        <classCode scheme="http://www.wikidata.org/entity/"><!-- Wikidata Code of the Genre --></classCode>
+      </textClass>
+      <creation>
+        <region>
+          <ref target="http://www.wikidata.org/entity/..."><!-- Name of the Region --></ref>
+        </region>
+      </creation>
+    </profileDesc>
+  </teiHeader>
+  <text>
+    <front>
+      <titlePage>
+        <docTitle>
+          <titlePart><!-- add title --></titlePart>
+        </docTitle>
+      </titlePage>
+    </front>
+    <body>
+      <div type="act" n="1">
+        <div type="scene" n="1">
+          <head><!-- heading of first act --></head>
+          <stage><!-- stage direction --></stage>
+          <sp who="#character_id">
+            <speaker><!-- Speaker Label --></speaker>
+            <l><!-- verse line --></l>
+          </sp>
+        </div>
+      </div>
+    </body>
+  </text>
 </TEI>

--- a/dracor/templates/NeoLatDraCor.xml
+++ b/dracor/templates/NeoLatDraCor.xml
@@ -1,12 +1,12 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://dracor.org/schema.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="neolatXXXXXX" xml:lang="lat">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="neolatXXXXXX" xml:lang="la">
    <teiHeader>
       <fileDesc>
          <titleStmt>
             <title><!-- title --></title>
             <author>
-               <persName xml:lang="eng"><!-- author's name --></persName>
+               <persName xml:lang="la"><!-- author's name --></persName>
                <idno type="wikidata"><!-- Wikidata ID of the author --></idno>
             </author>
             <respStmt>
@@ -35,15 +35,35 @@
          </publicationStmt>
          <sourceDesc>
             <bibl type="digitalSource">
-               <name><!-- Name of the Digital Source --></name>
+               <ref target="URL of digital source"><!-- Name of the Digital Source --></ref>
+               <availability>
+                  <licence target="URL of licence"><!-- Name of the Licence --></licence>
+               </availability>
             </bibl>
-            <bibl type="originalSource"><!-- Source --></bibl>
+
+            <bibl type="originalSource">
+               <author><!-- Author Name --></author>:
+               <title><!-- Title --></title>.
+               <pubPlace><!-- Publication Place --></pubPlace>:
+               <publisher><!-- Publisher --></publisher>,
+               <date><!-- Year --></date>.
+            </bibl>
+
+            <bibl type="wikidata">
+               <idno><!-- Wikidata QID --></idno>
+            </bibl>
+
+            <listEvent>
+               <event type="print" when=""><!-- add year -->
+                  <desc/>
+               </event>
+            </listEvent>
          </sourceDesc>
       </fileDesc>
       <profileDesc>
          <particDesc>
             <listPerson>
-               <person xml:id="character_id" sex="" role="">
+               <person xml:id="character_id">
                   <persName><!-- Character Name --></persName>
                </person>
                <!-- additional characters -->
@@ -57,19 +77,11 @@
          </textClass>
          <creation>
             <region>
-               <ref target=""><!-- Name of the Region --></ref>
+               <ref target="http://www.wikidata.org/entity/..."><!-- Name of the Region --></ref>
             </region>
          </creation>
       </profileDesc>
    </teiHeader>
-   <standOff>
-      <!-- listRelation -->
-      <listEvent>
-         <event type="print" when="">
-            <desc/>
-         </event>
-      </listEvent>
-   </standOff>
    <text>
       <front>
          <titlePage>

--- a/dracor/templates/drama.xml
+++ b/dracor/templates/drama.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://dracor.org/schema.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="" xml:lang="">
   <teiHeader>
@@ -12,7 +12,6 @@
             <surname></surname>
           </persName>
           <idno type="wikidata"></idno>
-          <idno type="pnd"></idno>
         </author>
       </titleStmt>
       <publicationStmt>
@@ -24,76 +23,79 @@
       </publicationStmt>
       <sourceDesc>
         <bibl type="digitalSource">
-          <name></name>
-          <idno type="URL"></idno>
+          <ref target="URL of digital source"></ref>
           <availability status="free">
             <p>In the public domain.</p>
           </availability>
-          <bibl type="originalSource">
-            <title>Autor: Title. Place: Publisher, 0000.</title>
-            </bibl>
         </bibl>
+        <bibl type="originalSource">
+          <author>Author</author>:
+          <title>Title</title>.
+          <pubPlace>Place</pubPlace>:
+          <publisher>Publisher</publisher>,
+          <date>0000</date>.
+        </bibl>
+        <!--
+        <bibl type="wikidata">
+          <idno>Q...</idno>
+        </bibl>
+
+        <listEvent>
+          <event type="print" when="">
+            <desc/>
+          </event>
+          <event type="premiere" when="">
+            <desc/>
+          </event>
+          <event type="written" when="">
+            <desc/>
+          </event>
+        </listEvent>
+        -->
       </sourceDesc>
     </fileDesc>
     <profileDesc>
       <particDesc>
         <listPerson>
-          <person xml:id="person-id" sex="">
+          <person xml:id="person-id">
             <persName></persName>
           </person>
-          <personGrp xml:id="group-id" sex="">
+          <personGrp xml:id="group-id">
             <name></name>
           </personGrp>
+          <!--
           <listRelation type="">
             <relation name="" active="#" passive="#"/>
           </listRelation>
+          -->
         </listPerson>
       </particDesc>
       <textClass>
         <keywords>
-          <term type="genreTitle"/>
+          <term type="genreTitle"></term>
         </keywords>
+        <classCode scheme="http://www.wikidata.org/entity/"></classCode>
       </textClass>
     </profileDesc>
-    <revisionDesc>
-      <listChange>
-        <change when="0000-00-00"></change>
-      </listChange>
-    </revisionDesc>
   </teiHeader>
-  <standOff>
-    <listEvent>
-      <event type="print" when="">
-        <desc/>
-      </event>
-      <event type="premiere" when="">
-        <desc/>
-      </event>
-      <event type="written" when="">
-        <desc/>
-      </event>
-    </listEvent>
-    <listRelation>
-      <relation name="wikidata" active="https://dracor.org/entity/" passive="http://www.wikidata.org/entity/"/>
-    </listRelation>
-  </standOff>
   <text>
     <front>
-      <div type="front">
-        <head></head>
-      </div>
-      <!-- ... -->
-      <div type="Dramatis_Personae">
-        <castList>
-          <head>Personen.</head>
-          <castItem>Luther.</castItem>
-          <castGroup>
-            <castItem></castItem>
-            <castItem></castItem>
-            <roleDesc></roleDesc>
-          </castGroup>
-        </castList>
-      </div>
+      <titlePage>
+        <docAuthor></docAuthor>
+        <docTitle>
+          <titlePart type="main"></titlePart>
+          <titlePart type="sub"></titlePart>
+        </docTitle>
+      </titlePage>
+      <castList>
+        <head>Personen.</head>
+        <castItem>Luther.</castItem>
+        <castGroup>
+          <castItem></castItem>
+          <castItem></castItem>
+          <roleDesc></roleDesc>
+        </castGroup>
+      </castList>
       <set>
         <p>Setting</p>
       </set>
@@ -111,8 +113,8 @@
             <p>Text</p>
           </sp>
         </div>
-          <trailer>Ende.</trailer>
-        </div>
+        <trailer>Ende.</trailer>
+      </div>
     </body>
   </text>
 </TEI>

--- a/dracor/templates/ham.xml
+++ b/dracor/templates/ham.xml
@@ -1,114 +1,114 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Basic file to test the features of DraCor plays -->
 <TEI xmlns="http://www.tei-c.org/ns/1.0" type="dracor" xml:id="tst000000" xml:lang="en">
-    <teiHeader>
-        <fileDesc>
-            <titleStmt>
-                <title>Ham</title>
-                <title type="sub">A Tragedy</title>
-                <author>William S</author>
-            </titleStmt>
-            <publicationStmt>
-                <publisher xml:id="dracor">DraCor</publisher>
-                <idno type="URL">https://dracor.org</idno>
-                <availability>
-                    <licence target="https://creativecommons.org/publicdomain/zero/1.0/">CC0 1.0</licence>
-                </availability>
-            </publicationStmt>
-            <sourceDesc>
-                <bibl type="digitalSource">
-                    <ref target="https://github.com/dracor-org/dracor-schema">
-                        dracor-schema GitHub Repository
-                    </ref>
-                    <availability>
-                        <licence target="https://creativecommons.org/licenses/by/4.0/">CC BY 4.0</licence>
-                    </availability>
-                </bibl>
-                <bibl type="originalSource">
-                    Slides of the Hebrew and Yiddish DraCor Working group
-                    meeting on 2022-11-14 by Daniil Skorinkin
-                </bibl>
-                <listEvent>
-                    <event type="print" when="2023">
-                        <desc/>
-                    </event>
-                    <event type="written" when="2022">
-                        <desc/>
-                    </event>
-                </listEvent>
-            </sourceDesc>
-        </fileDesc>
-        <profileDesc>
-            <particDesc>
-                <listPerson>
-                    <person xml:id="ham">
-                        <persName>Ham</persName>
-                    </person>
-                    <person xml:id="egg">
-                        <persName>Egg</persName>
-                    </person>
-                    <person xml:id="sausage">
-                        <persName>Sausage</persName>
-                    </person>
-                    <person xml:id="bacon">
-                        <persName>Bacon</persName>
-                    </person>
-                </listPerson>
-            </particDesc>
-        </profileDesc>
-    </teiHeader>
-    <text>
-        <front>
-            <titlePage>
-                <docTitle>
-                    <titlePart>Ham,</titlePart>
-                    <titlePart>a tragedy</titlePart>
-                </docTitle>
-                <docAuthor>By William S</docAuthor>
-            </titlePage>
-            <castList>
-                <head>Dramatis Personae</head>
-                <castItem>Ham</castItem>
-                <castItem>Egg</castItem>
-                <castGroup>
-                    <castItem>Sausage</castItem>
-                    <castItem>Bacon</castItem>
-                    <roleDesc>Vikings</roleDesc>
-                </castGroup>
-            </castList>
-        </front>
-        <body>
-            <div type="act">
-                <head>Act 1.</head>
-                <div type="scene">
-                    <head>Scene 1.</head>
-                    <stage>Ham and Egg.</stage>
-                    <sp who="#ham">
-                        <speaker>Ham.</speaker>
-                        <p>Lovely Spam!</p>
-                    </sp>
-                    <sp who="#egg">
-                        <speaker>Egg.</speaker>
-                        <p>Wonderful Spam!</p>
-                    </sp>
-                </div>
-                <div type="scene">
-                    <head>Scene 2.</head>
-                    <stage>Enter Vikings.</stage>
-                    <sp who="#ham">
-                        <speaker>Ham.</speaker>
-                        <p>Egg! Sausage, and Bacon!</p>
-                    </sp>
-                    <sp who="#sausage #bacon">
-                        <speaker>Vikings</speaker>
-                        <stage>(singing).</stage>
-                        <l>Spam, Spam, Spam,</l>
-                        <l>Spam, Spam, Spam,</l>
-                        <l>Spam and Spam!</l>
-                    </sp>
-                    <stage>The End.</stage>
-                </div>
-            </div>
-        </body>
-    </text>
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Ham</title>
+        <title type="sub">A Tragedy</title>
+        <author>William S</author>
+      </titleStmt>
+      <publicationStmt>
+        <publisher xml:id="dracor">DraCor</publisher>
+        <idno type="URL">https://dracor.org</idno>
+        <availability>
+          <licence target="https://creativecommons.org/publicdomain/zero/1.0/">CC0 1.0</licence>
+        </availability>
+      </publicationStmt>
+      <sourceDesc>
+        <bibl type="digitalSource">
+          <ref target="https://github.com/dracor-org/dracor-schema">
+            dracor-schema GitHub Repository
+          </ref>
+          <availability>
+            <licence target="https://creativecommons.org/licenses/by/4.0/">CC BY 4.0</licence>
+          </availability>
+        </bibl>
+        <bibl type="originalSource">
+          Slides of the Hebrew and Yiddish DraCor Working group meeting on
+          2022-11-14 by Daniil Skorinkin
+        </bibl>
+        <listEvent>
+          <event type="print" when="2023">
+            <desc/>
+          </event>
+          <event type="written" when="2022">
+            <desc/>
+          </event>
+        </listEvent>
+      </sourceDesc>
+    </fileDesc>
+    <profileDesc>
+      <particDesc>
+        <listPerson>
+          <person xml:id="ham">
+            <persName>Ham</persName>
+          </person>
+          <person xml:id="egg">
+            <persName>Egg</persName>
+          </person>
+          <person xml:id="sausage">
+            <persName>Sausage</persName>
+          </person>
+          <person xml:id="bacon">
+            <persName>Bacon</persName>
+          </person>
+        </listPerson>
+      </particDesc>
+    </profileDesc>
+  </teiHeader>
+  <text>
+    <front>
+      <titlePage>
+        <docTitle>
+          <titlePart>Ham,</titlePart>
+          <titlePart>a tragedy</titlePart>
+        </docTitle>
+        <docAuthor>By William S</docAuthor>
+      </titlePage>
+      <castList>
+        <head>Dramatis Personae</head>
+        <castItem>Ham</castItem>
+        <castItem>Egg</castItem>
+        <castGroup>
+          <castItem>Sausage</castItem>
+          <castItem>Bacon</castItem>
+          <roleDesc>Vikings</roleDesc>
+        </castGroup>
+      </castList>
+    </front>
+    <body>
+      <div type="act">
+        <head>Act 1.</head>
+        <div type="scene">
+          <head>Scene 1.</head>
+          <stage>Ham and Egg.</stage>
+          <sp who="#ham">
+            <speaker>Ham.</speaker>
+            <p>Lovely Spam!</p>
+          </sp>
+          <sp who="#egg">
+            <speaker>Egg.</speaker>
+            <p>Wonderful Spam!</p>
+          </sp>
+        </div>
+        <div type="scene">
+          <head>Scene 2.</head>
+          <stage>Enter Vikings.</stage>
+          <sp who="#ham">
+            <speaker>Ham.</speaker>
+            <p>Egg! Sausage, and Bacon!</p>
+          </sp>
+          <sp who="#sausage #bacon">
+            <speaker>Vikings</speaker>
+            <stage>(singing).</stage>
+            <l>Spam, Spam, Spam,</l>
+            <l>Spam, Spam, Spam,</l>
+            <l>Spam and Spam!</l>
+          </sp>
+          <stage>The End.</stage>
+        </div>
+      </div>
+    </body>
+  </text>
 </TEI>

--- a/dracor/templates/ham.xml
+++ b/dracor/templates/ham.xml
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Basic File to Test the Features of DraCor Plays -->
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="tst000000" xml:lang="eng">
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Basic file to test the features of DraCor plays -->
+<TEI xmlns="http://www.tei-c.org/ns/1.0" type="dracor" xml:id="tst000000" xml:lang="en">
     <teiHeader>
         <fileDesc>
             <titleStmt>
@@ -17,11 +17,25 @@
             </publicationStmt>
             <sourceDesc>
                 <bibl type="digitalSource">
-                    <name>dracor-schema GitHub Repository</name>
-                    <bibl type="originalSource">
-                        <title>Slides of the Hebrew and Yiddish DraCor Working group meeting on 2022-11-14 by Daniil Skorinkin</title>
-                    </bibl>
+                    <ref target="https://github.com/dracor-org/dracor-schema">
+                        dracor-schema GitHub Repository
+                    </ref>
+                    <availability>
+                        <licence target="https://creativecommons.org/licenses/by/4.0/">CC BY 4.0</licence>
+                    </availability>
                 </bibl>
+                <bibl type="originalSource">
+                    Slides of the Hebrew and Yiddish DraCor Working group
+                    meeting on 2022-11-14 by Daniil Skorinkin
+                </bibl>
+                <listEvent>
+                    <event type="print" when="2023">
+                        <desc/>
+                    </event>
+                    <event type="written" when="2022">
+                        <desc/>
+                    </event>
+                </listEvent>
             </sourceDesc>
         </fileDesc>
         <profileDesc>
@@ -42,37 +56,26 @@
                 </listPerson>
             </particDesc>
         </profileDesc>
-        <revisionDesc>
-            <change when="2022-11-07">Describe Change!</change>
-        </revisionDesc>
     </teiHeader>
-    <standOff>
-        <listEvent>
-            <event type="print" when="2023">
-                <desc/>
-            </event>
-            <event type="written" when="2022">
-                <desc/>
-            </event>
-        </listEvent>
-    </standOff>
     <text>
         <front>
-            <div type="front">
-                <head>Ham, a tragedy By William S</head>
-            </div>
-            <div type="Dramatis_Personae">
-                <castList>
-                    <head>Dramatis Personae</head>
-                    <castItem>Ham</castItem>
-                    <castItem>Egg</castItem>
-                    <castGroup>
-                        <castItem>Sausage</castItem>
-                        <castItem>Bacon</castItem>
-                        <roleDesc>Vikings</roleDesc>
-                    </castGroup>
-                </castList>
-            </div>
+            <titlePage>
+                <docTitle>
+                    <titlePart>Ham,</titlePart>
+                    <titlePart>a tragedy</titlePart>
+                </docTitle>
+                <docAuthor>By William S</docAuthor>
+            </titlePage>
+            <castList>
+                <head>Dramatis Personae</head>
+                <castItem>Ham</castItem>
+                <castItem>Egg</castItem>
+                <castGroup>
+                    <castItem>Sausage</castItem>
+                    <castItem>Bacon</castItem>
+                    <roleDesc>Vikings</roleDesc>
+                </castGroup>
+            </castList>
         </front>
         <body>
             <div type="act">
@@ -106,7 +109,6 @@
                     <stage>The End.</stage>
                 </div>
             </div>
-            
         </body>
     </text>
 </TEI>


### PR DESCRIPTION
This includes changes in the upcoming schema version 1.4.0. deprecating `<standOff>`. It anticipates the changes in dracor-org/dracor-schema#184 but should be backwards compatible.

The goal was to make the templates as valid as possible which is why I removed the `@sex` attributes in the `particDesc` entries. I consider this preferable to the alternative of using a default which may not be accurate for the play the template is used for. Now there is only one validation error for the `@when` attribute which, when removed, would render the `event` element basically meaningless.

resolve #18